### PR TITLE
Automatically refresh access token

### DIFF
--- a/class-wpzoom-instagram-image-uploader.php
+++ b/class-wpzoom-instagram-image-uploader.php
@@ -99,7 +99,7 @@ class WPZOOM_Instagram_Image_Uploader {
 	 * @return float|int
 	 */
 	function get_transient_lifetime() {
-		$options = get_option( 'wpzoom-instagram-widget-settings', wpzoom_instagram_get_default_settings() );
+		$options = Wpzoom_Instagram_Widget_Settings::$settings;
 
 		$values = array(
 			'minutes' => MINUTE_IN_SECONDS,

--- a/class-wpzoom-instagram-widget-api.php
+++ b/class-wpzoom-instagram-widget-api.php
@@ -163,9 +163,6 @@ class Wpzoom_Instagram_Widget_API {
 					$notice_message  = '<strong>' . __( 'Your Access Token for Instagram Widget has expired!', 'instagram-widget-by-wpzoom' ) . '</strong><br/>';
 					$notice_message .= sprintf( __( 'We cannot update access tokens automatically for Instagram private accounts. You need manually to generate a new access token, reauthorize here: %1$s.', 'instagram-widget-by-wpzoom' ), '<a href="' . esc_url( $settings_url ) . '">' . __( 'Instagram Widget Settings', 'instagram-widget-by-wpzoom' ) . '</a>' ) . '&nbsp;';
 					$notice_message .= '<a style="text-decoration: none" class="notice-dismiss" href="' . $hide_notices_url . '"></a>';
-				} elseif ( 10 === $data->error->code && self::is_access_token_valid( $this->access_token ) ) {
-					$expires_in     = '120'; // TODO: try to get expires_in value
-					$notice_message = sprintf( __( 'Your Instagram Access Token expires on %1$s! We cannot update access tokens automatically for Instagram private accounts. You need manually to generate a new one, reauthorize here: %2$s.', 'instagram-widget-by-wpzoom' ), $expires_in, '<a href="' . esc_url( $settings_url ) . '">' . __( 'Instagram Widget Settings', 'instagram-widget-by-wpzoom' ) . '</a>' ) . '&nbsp;';
 				}
 
 				$stored_data['admin-notice-message'] = $notice_message;

--- a/class-wpzoom-instagram-widget-api.php
+++ b/class-wpzoom-instagram-widget-api.php
@@ -174,9 +174,14 @@ class Wpzoom_Instagram_Widget_API {
 		return false;
 	}
 
-	public static function reset_cache() {
+	public static function reset_cache( $sanitized_data ) {
 		delete_transient( 'zoom_instagram_is_configured' );
 		delete_transient( 'zoom_instagram_user_info' );
+
+		// Remove schedule hook `wpzoom_instagram_widget_cron_hook`.
+		if ( empty( $sanitized_data['basic-access-token'] ) ) {
+			wp_clear_scheduled_hook( 'wpzoom_instagram_widget_cron_hook' );
+		}
 	}
 
 	/**

--- a/class-wpzoom-instagram-widget-api.php
+++ b/class-wpzoom-instagram-widget-api.php
@@ -133,12 +133,11 @@ class Wpzoom_Instagram_Widget_API {
 			}
 
 			if ( 200 === $response_code ) {
-				$stored_data['basic-access-token'] = $data->access_token;
-
 				$date_format    = get_option( 'date_format' );
 				$time_format    = get_option( 'time_format' );
 				$notice_message = sprintf( __( 'Instagram Access Token was refreshed automatically on %1$s at %2$s', 'instagram-widget-by-wpzoom' ), date( $date_format ), date( $time_format ) );
 
+				$stored_data['basic-access-token']   = $data->access_token;
 				$stored_data['refresh-access-token'] = $notice_message;
 			} else {
 				if ( ! isset( $data->error ) ) {
@@ -171,7 +170,7 @@ class Wpzoom_Instagram_Widget_API {
 				update_user_meta( $user_id, 'wpzoom_instagram_admin_notice', false );
 			}
 
-			return update_option( 'wpzoom-instagram-widget-settings', $stored_data );
+			return update_option( Wpzoom_Instagram_Widget_Settings::$option_name, $stored_data );
 		}
 
 		return false;

--- a/class-wpzoom-instagram-widget-settings.php
+++ b/class-wpzoom-instagram-widget-settings.php
@@ -7,7 +7,17 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 class Wpzoom_Instagram_Widget_Settings {
+	/**
+	 * Stores settings options
+	 *
+	 * @since 1.8.0
+	 * @var array
+	 */
+	public static $settings = array();
+
 	public function __construct() {
+		self::$settings = get_option( 'wpzoom-instagram-widget-settings', wpzoom_instagram_get_default_settings() );
+
 		add_action( 'admin_menu', array( $this, 'add_admin_menu' ) );
 		add_action( 'admin_init', array( $this, 'settings_init' ) );
 
@@ -171,7 +181,7 @@ class Wpzoom_Instagram_Widget_Settings {
 	}
 
 	public function settings_field_basic_access_token_button() {
-		$settings = get_option( 'wpzoom-instagram-widget-settings', wpzoom_instagram_get_default_settings() );
+		$settings = self::$settings;
 
 		$oauth_url  = add_query_arg(
 			array(
@@ -202,7 +212,7 @@ class Wpzoom_Instagram_Widget_Settings {
 	}
 
 	public function settings_field_transient_lifetime() {
-		$settings       = get_option( 'wpzoom-instagram-widget-settings', wpzoom_instagram_get_default_settings() );
+		$settings       = self::$settings;
 		$lifetime_value = ! empty( $settings['transient-lifetime-value'] ) ? $settings['transient-lifetime-value'] : 1;
 		$lifetime_type  = ! empty( $settings['transient-lifetime-type'] ) ? $settings['transient-lifetime-type'] : 'days';
 		?>
@@ -227,7 +237,7 @@ class Wpzoom_Instagram_Widget_Settings {
 	}
 
 	public function settings_field_is_forced_timeout() {
-		$settings          = get_option( 'wpzoom-instagram-widget-settings', wpzoom_instagram_get_default_settings() );
+		$settings          = self::$settings;
 		$is_forced_timeout = ! empty( $settings['is-forced-timeout'] ) ? wp_validate_boolean( $settings['is-forced-timeout'] ) : false;
 		?>
 		<input class="regular-text code"
@@ -241,7 +251,7 @@ class Wpzoom_Instagram_Widget_Settings {
 	}
 
 	public function settings_field_request_timeout() {
-		$settings      = get_option( 'wpzoom-instagram-widget-settings', wpzoom_instagram_get_default_settings() );
+		$settings      = self::$settings;
 		$timeout_value = ! empty( $settings['request-timeout-value'] ) ? $settings['request-timeout-value'] : 15;
 		?>
 		<input class="regular-text code"
@@ -259,7 +269,7 @@ class Wpzoom_Instagram_Widget_Settings {
 	}
 
 	public function settings_field_basic_access_token_input() {
-		$settings           = get_option( 'wpzoom-instagram-widget-settings', wpzoom_instagram_get_default_settings() );
+		$settings           = self::$settings;
 		$basic_access_token = ! empty( $settings['basic-access-token'] ) ? $settings['basic-access-token'] : '';
 		?>
 		<input class="regular-text code" id="wpzoom-instagram-widget-settings_basic-access-token"
@@ -298,7 +308,7 @@ class Wpzoom_Instagram_Widget_Settings {
 
 
 	public function settings_field_username() {
-		$settings = get_option( 'wpzoom-instagram-widget-settings', wpzoom_instagram_get_default_settings() );
+		$settings = self::$settings;
 		?>
 		<input class="regular-text code" id="wpzoom-instagram-widget-settings_username"
 			   name="wpzoom-instagram-widget-settings[username]" value="<?php echo esc_attr( $settings['username'] ); ?>"
@@ -317,7 +327,7 @@ class Wpzoom_Instagram_Widget_Settings {
 	}
 
 	public function settings_field_request_type() {
-		$settings     = get_option( 'wpzoom-instagram-widget-settings', wpzoom_instagram_get_default_settings() );
+		$settings     = self::$settings;
 		$request_type = empty( $settings['request-type'] ) ? 'with-basic-access-token' : $settings['request-type'];
 		?>
 
@@ -351,7 +361,7 @@ class Wpzoom_Instagram_Widget_Settings {
 	}
 
 	public function settings_field_user_info_fullname() {
-		$settings           = get_option( 'wpzoom-instagram-widget-settings', wpzoom_instagram_get_default_settings() );
+		$settings           = self::$settings;
 		$user_info_fullname = empty( $settings['user-info-fullname'] ) ? '' : $settings['user-info-fullname'];
 		?>
 		<input class="code"
@@ -363,7 +373,7 @@ class Wpzoom_Instagram_Widget_Settings {
 	}
 
 	public function settings_field_user_info_avatar() {
-		$settings         = get_option( 'wpzoom-instagram-widget-settings', wpzoom_instagram_get_default_settings() );
+		$settings         = self::$settings;
 		$user_info_avatar = empty( $settings['user-info-avatar'] ) ? '' : $settings['user-info-avatar'];
 		?>
 		<div class="zoom-instagram-user-avatar-media-uploader"
@@ -387,7 +397,7 @@ class Wpzoom_Instagram_Widget_Settings {
 	}
 
 	public function settings_field_user_info_biography() {
-		$settings            = get_option( 'wpzoom-instagram-widget-settings', wpzoom_instagram_get_default_settings() );
+		$settings            = self::$settings;
 		$user_info_biography = empty( $settings['user-info-biography'] ) ? '' : $settings['user-info-biography'];
 		?>
 		<textarea class="code"
@@ -454,7 +464,8 @@ class Wpzoom_Instagram_Widget_Settings {
 	}
 
 	public function sanitize( $input ) {
-		$result = array();
+		$result   = array();
+		$settings = self::$settings;
 
 		$result['basic-access-token'] = sanitize_text_field( $input['basic-access-token'] );
 		$result['request-type']       = sanitize_text_field( $input['request-type'] );
@@ -479,6 +490,16 @@ class Wpzoom_Instagram_Widget_Settings {
 				}
 
 				$result['basic-access-token'] = '';
+			}
+
+			if ( isset( $settings['refresh-access-token'] ) && ! empty( $settings['refresh-access-token'] ) ) {
+				// Inform user in settings page when Access Token was refreshed.
+				add_settings_error(
+					'wpzoom-instagram-widget-access-token',
+					esc_attr( 'wpzoom-instagram-widget-refresh-access-token' ),
+					$settings['refresh-access-token'],
+					'info'
+				);
 			}
 		}
 

--- a/class-wpzoom-instagram-widget-settings.php
+++ b/class-wpzoom-instagram-widget-settings.php
@@ -15,6 +15,14 @@ class Wpzoom_Instagram_Widget_Settings {
 	 */
 	public static $settings = array();
 
+	/**
+	 * Settings option name
+	 *
+	 * @since 1.8.0
+	 * @var string
+	 */
+	public static $option_name = 'wpzoom-instagram-widget-settings';
+
 	public function __construct() {
 		self::$settings = get_option( 'wpzoom-instagram-widget-settings', wpzoom_instagram_get_default_settings() );
 
@@ -464,8 +472,7 @@ class Wpzoom_Instagram_Widget_Settings {
 	}
 
 	public function sanitize( $input ) {
-		$result   = array();
-		$settings = self::$settings;
+		$result = array();
 
 		$result['basic-access-token'] = sanitize_text_field( $input['basic-access-token'] );
 		$result['request-type']       = sanitize_text_field( $input['request-type'] );
@@ -490,16 +497,6 @@ class Wpzoom_Instagram_Widget_Settings {
 				}
 
 				$result['basic-access-token'] = '';
-			}
-
-			if ( isset( $settings['refresh-access-token'] ) && ! empty( $settings['refresh-access-token'] ) ) {
-				// Inform user in settings page when Access Token was refreshed.
-				add_settings_error(
-					'wpzoom-instagram-widget-access-token',
-					esc_attr( 'wpzoom-instagram-widget-refresh-access-token' ),
-					$settings['refresh-access-token'],
-					'info'
-				);
 			}
 		}
 

--- a/class-wpzoom-instagram-widget-settings.php
+++ b/class-wpzoom-instagram-widget-settings.php
@@ -491,7 +491,7 @@ class Wpzoom_Instagram_Widget_Settings {
 		$result['user-info-fullname']       = sanitize_text_field( $input['user-info-fullname'] );
 		$result['user-info-biography']      = sanitize_text_field( $input['user-info-biography'] );
 
-		Wpzoom_Instagram_Widget_API::reset_cache();
+		Wpzoom_Instagram_Widget_API::reset_cache( $result );
 
 		return $result;
 	}

--- a/instagram-widget-by-wpzoom.php
+++ b/instagram-widget-by-wpzoom.php
@@ -37,7 +37,7 @@ function zoom_instagram_widget_register() {
 add_action( 'admin_notices', 'wpzoom_instagram_admin_notice' );
 
 function wpzoom_instagram_admin_notice() {
-	global $current_user;
+	global $current_user, $pagenow;
 
 	if ( ! current_user_can( 'manage_options' ) ) {
 		return;
@@ -55,7 +55,7 @@ function wpzoom_instagram_admin_notice() {
 
 		$options['admin-notice-message'] = $notice_message;
 
-		update_option( 'wpzoom-instagram-widget-settings', $options );
+		update_option( Wpzoom_Instagram_Widget_Settings::$option_name, $options );
 	}
 
 	/* Check that the user hasn't already clicked to ignore the message */
@@ -65,6 +65,22 @@ function wpzoom_instagram_admin_notice() {
 			echo '<div class="notice-warning notice" style="position:relative"><p>';
 			echo wp_kses_post( $options['admin-notice-message'] );
 			echo '</p></div>';
+		}
+	}
+
+	if ( 'options-general.php' === $pagenow && ( isset( $_GET['page'] ) && 'wpzoom-instagram-widget' === $_GET['page'] ) ) {
+		if ( isset( $options['refresh-access-token'] ) && ! empty( $options['refresh-access-token'] ) ) {
+			// Inform user in settings page when Access Token was refreshed.
+			add_settings_error(
+				'wpzoom-instagram-refresh-access-token',
+				esc_attr( 'wpzoom-instagram-widget-refresh-access-token' ),
+				$options['refresh-access-token'],
+				'info'
+			);
+
+			$options['refresh-access-token'] = '';
+
+			update_option( Wpzoom_Instagram_Widget_Settings::$option_name, $options );
 		}
 	}
 }

--- a/instagram-widget-by-wpzoom.php
+++ b/instagram-widget-by-wpzoom.php
@@ -138,3 +138,9 @@ function wpzoom_instagram_load_plugin_textdomain() {
 	load_plugin_textdomain( 'instagram-widget-by-wpzoom', false, basename( dirname( __FILE__ ) ) . '/languages/' );
 }
 add_action( 'init', 'wpzoom_instagram_load_plugin_textdomain' );
+
+register_deactivation_hook( __FILE__, 'wpzoom_instagram_plugin_deactivation' );
+
+function wpzoom_instagram_plugin_deactivation() {
+	wp_clear_scheduled_hook( 'wpzoom_instagram_widget_cron_hook' );
+}

--- a/instagram-widget-by-wpzoom.php
+++ b/instagram-widget-by-wpzoom.php
@@ -37,36 +37,35 @@ function zoom_instagram_widget_register() {
 add_action( 'admin_notices', 'wpzoom_instagram_admin_notice' );
 
 function wpzoom_instagram_admin_notice() {
+	global $current_user;
+
 	if ( ! current_user_can( 'manage_options' ) ) {
 		return;
 	}
 
-	global $current_user;
-	$user_id = $current_user->ID;
+	$options = get_option( 'wpzoom-instagram-widget-settings', wpzoom_instagram_get_default_settings() );
+
+	if ( ! isset( $options['basic-access-token'] ) || empty( $options['basic-access-token'] ) ) {
+		$hide_notices_url = wpzoom_instagram_get_notice_dismiss_url();
+
+		$notice_message  = '<strong>' . __( 'Please configure Instagram Widget', 'instagram-widget-by-wpzoom' ) . '</strong><br/><br/>';
+		$notice_message .= sprintf( __( 'If you have just installed or updated this plugin, please go to the %1$s and %2$s it with your Instagram account.', 'instagram-widget-by-wpzoom' ), '<a href="options-general.php?page=wpzoom-instagram-widget">' . __( 'Settings page', 'instagram-widget-by-wpzoom' ) . '</a>', '<strong>' . __( 'connect', 'instagram-widget-by-wpzoom' ) . '</strong>' ) . '&nbsp;';
+		$notice_message .= __( 'You have to generate Instagram Access Token to allow widget to display your media.', 'instagram-widget-by-wpzoom' );
+		$notice_message .= '<a style="text-decoration: none" class="notice-dismiss" href="' . $hide_notices_url . '"></a>';
+
+		$options['admin-notice-message'] = $notice_message;
+
+		update_option( 'wpzoom-instagram-widget-settings', $options );
+	}
+
 	/* Check that the user hasn't already clicked to ignore the message */
-	if ( ! get_user_meta( $user_id, 'wpzoom_instagram_admin_notice' ) ) {
-		/**
-		 * Fixed dismiss url
-		 *
-		 * @since 1.7.5
-		 */
-		$hide_notices_url = html_entity_decode( // to convert &amp;s to normal &, otherwise produces invalid link.
-			add_query_arg(
-				array(
-					'wpzoom_instagram_ignore_admin_notice' => '0',
-				),
-				wpzoom_instagram_get_current_admin_url() ? wpzoom_instagram_get_current_admin_url() : admin_url( 'options-general.php?page=wpzoom-instagram-widget' )
-			)
-		);
-
-		$configure_message  = '<strong>' . __( 'Please configure Instagram Widget', 'instagram-widget-by-wpzoom' ) . '</strong><br/><br/>';
-		$configure_message .= sprintf( __( 'If you have just installed or updated this plugin, please go to the %1$s and %2$s it with your Instagram account.', 'instagram-widget-by-wpzoom' ), '<a href="options-general.php?page=wpzoom-instagram-widget">' . __( 'Settings page', 'instagram-widget-by-wpzoom' ) . '</a>', '<strong>' . __( 'connect', 'instagram-widget-by-wpzoom' ) . '</strong>' ) . '&nbsp;';
-		$configure_message .= __( 'You can ignore this message if you have already configured it.', 'instagram-widget-by-wpzoom' );
-		$configure_message .= '<a style="text-decoration: none" class="notice-dismiss" href="' . $hide_notices_url . '"></a>';
-
-		echo '<div class="notice-warning notice" style="position:relative"><p>';
-		echo wp_kses_post( $configure_message );
-		echo '</p></div>';
+	$user_id = $current_user->ID;
+	if ( ! get_user_meta( $user_id, 'wpzoom_instagram_admin_notice', true ) ) {
+		if ( isset( $options['admin-notice-message'] ) && ! empty( $options['admin-notice-message'] ) ) {
+			echo '<div class="notice-warning notice" style="position:relative"><p>';
+			echo wp_kses_post( $options['admin-notice-message'] );
+			echo '</p></div>';
+		}
 	}
 }
 
@@ -81,6 +80,21 @@ function wpzoom_instagram_ignore_admin_notice() {
 	}
 }
 
+function wpzoom_instagram_get_notice_dismiss_url() {
+	/**
+	 * Fixed dismiss url
+	 *
+	 * @since 1.7.5
+	 */
+	$hide_notices_url = html_entity_decode( // to convert &amp;s to normal &, otherwise produces invalid link.
+		add_query_arg(
+			array(
+				'wpzoom_instagram_ignore_admin_notice' => '0',
+			),
+			wpzoom_instagram_get_current_admin_url() ? wpzoom_instagram_get_current_admin_url() : admin_url( 'options-general.php?page=wpzoom-instagram-widget' )
+		)
+	);
+}
 
 function wpzoom_instagram_get_default_settings() {
 	return array(

--- a/instagram-widget-by-wpzoom.php
+++ b/instagram-widget-by-wpzoom.php
@@ -43,12 +43,12 @@ function wpzoom_instagram_admin_notice() {
 		return;
 	}
 
-	$options = get_option( 'wpzoom-instagram-widget-settings', wpzoom_instagram_get_default_settings() );
+	$options = Wpzoom_Instagram_Widget_Settings::$settings;
 
 	if ( ! isset( $options['basic-access-token'] ) || empty( $options['basic-access-token'] ) ) {
 		$hide_notices_url = wpzoom_instagram_get_notice_dismiss_url();
 
-		$notice_message  = '<strong>' . __( 'Please configure Instagram Widget', 'instagram-widget-by-wpzoom' ) . '</strong><br/><br/>';
+		$notice_message  = '<strong>' . __( 'Please configure Instagram Widget', 'instagram-widget-by-wpzoom' ) . '</strong><br/>';
 		$notice_message .= sprintf( __( 'If you have just installed or updated this plugin, please go to the %1$s and %2$s it with your Instagram account.', 'instagram-widget-by-wpzoom' ), '<a href="options-general.php?page=wpzoom-instagram-widget">' . __( 'Settings page', 'instagram-widget-by-wpzoom' ) . '</a>', '<strong>' . __( 'connect', 'instagram-widget-by-wpzoom' ) . '</strong>' ) . '&nbsp;';
 		$notice_message .= __( 'You have to generate Instagram Access Token to allow widget to display your media.', 'instagram-widget-by-wpzoom' );
 		$notice_message .= '<a style="text-decoration: none" class="notice-dismiss" href="' . $hide_notices_url . '"></a>';


### PR DESCRIPTION
This endpoint allows you to refresh long-lived Instagram User Access Tokens for **public** Instagram accounts.
Refresh a long-lived Instagram User Access Token that is at least 24 hours old but has not expired. Refreshed tokens are valid for 60 days from the date at which they are refreshed.