### PR TITLE
fix: print styles after content

### DIFF
--- a/includes/class-wpzoom-instagram-widget-display.php
+++ b/includes/class-wpzoom-instagram-widget-display.php
@@ -513,9 +513,9 @@ class Wpzoom_Instagram_Widget_Display {
 
 			if ( $feed_id > -1 ) {
 				return sprintf(
-					"<style type=\"text/css\">%s</style>\n%s",
-					$this->output_styles( $feed_id, false ),
-					$this->get_feed_output( $feed_id )
+					"%s\n<style type=\"text/css\">%s</style>",
+					$this->get_feed_output( $feed_id ),
+					$this->output_styles( $feed_id, false )
 				);
 			}
 		}
@@ -536,9 +536,9 @@ class Wpzoom_Instagram_Widget_Display {
 	 */
 	public function output_feed( int $feed_id, bool $echo = true, array $extra_attrs = array() ) {
 		$output = sprintf(
-			"<style type=\"text/css\">%s</style>\n%s",
-			$this->output_styles( $feed_id, false ),
-			$this->get_feed_output( $feed_id, $extra_attrs )
+			"%s\n<style type=\"text/css\">%s</style>",
+			$this->get_feed_output( $feed_id, $extra_attrs ),
+			$this->output_styles( $feed_id, false )
 		);
 
 		if ( $echo ) {


### PR DESCRIPTION
WordPress's block support processor targets the first HTML element in a `render_callback` output to apply the visibility classes. The `<style>` tag was being prepended to the output, making it the first element and causing those classes to be added to it instead of the `.zoom-instagram` element. Moving the `<style>` output to after `.zoom-instagram` resolves this.

<img width="306" height="161" alt="image" src="https://github.com/user-attachments/assets/20263ee4-f358-4e3f-ba34-6e9d40f95273" />
